### PR TITLE
dark mode feature!

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@heroicons/vue": "^2.0.18",
         "@inertiajs/vue3": "^1.0.6",
+        "@vueuse/core": "^10.2.0",
         "dayjs": "^1.11.7",
         "preline": "^1.8.0",
         "vue": "^3.3.2"

--- a/resources/js/Components/Layouts/AppLayout.vue
+++ b/resources/js/Components/Layouts/AppLayout.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="bg-gray-50 min-h-screen dark:bg-slate-900">
+    <div class="bg-gray-50 min-h-screen dark:bg-slate-900 transition-colors duration-300">
         <Head :title="title"/>
         <!-- ========== HEADER ========== -->
         <Header/>

--- a/resources/js/Components/Layouts/AppLayout.vue
+++ b/resources/js/Components/Layouts/AppLayout.vue
@@ -1,6 +1,8 @@
 <template>
     <div class="bg-gray-50 min-h-screen dark:bg-slate-900 transition-colors duration-300">
-        <Head :title="title"/>
+        <Head>
+            <title>{{title}}</title>
+        </Head>
         <!-- ========== HEADER ========== -->
         <Header/>
         <!-- ========== END HEADER ========== -->

--- a/resources/js/Components/Layouts/Partials/Header.vue
+++ b/resources/js/Components/Layouts/Partials/Header.vue
@@ -40,6 +40,7 @@ const page = usePage();
                             </div>
                             <div class="mt-2 py-2 first:pt-0 last:pb-0">
                                 <Link :href="route('logout')"
+                                      as="button"
                                       method="POST"
                                       class="flex w-full items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300">
                                     <ArrowLeftOnRectangleIcon class="flex-none w-5 h-5"/>

--- a/resources/js/Components/Layouts/Partials/Header.vue
+++ b/resources/js/Components/Layouts/Partials/Header.vue
@@ -12,7 +12,7 @@ const page = usePage();
         class="sticky top-0 inset-x-0 flex flex-wrap sm:justify-start sm:flex-nowrap z-[48] w-full bg-white border-b text-sm py-2.5 sm:py-4 lg:pl-64 dark:bg-gray-800 dark:border-gray-700">
         <nav class="flex basis-full items-center w-full mx-auto px-4 sm:px-6 md:px-8" aria-label="Global">
             <div class="mr-5 lg:mr-0 lg:hidden">
-                <Link as="h1" class="flex-none cursor-pointer text-xl font-semibold dark:text-white"
+                <Link class="flex-none cursor-pointer text-xl font-semibold dark:text-white"
                       :href="route('dashboard')"
                       aria-label="SPM Widyatama">SPM Widyatama
                 </Link>
@@ -41,7 +41,6 @@ const page = usePage();
                             <div class="mt-2 py-2 first:pt-0 last:pb-0">
                                 <Link :href="route('logout')"
                                       method="POST"
-                                      as="button"
                                       class="flex w-full items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300">
                                     <ArrowLeftOnRectangleIcon class="flex-none w-5 h-5"/>
                                     Logout

--- a/resources/js/Components/Layouts/Partials/Header.vue
+++ b/resources/js/Components/Layouts/Partials/Header.vue
@@ -1,3 +1,12 @@
+<script setup>
+import {Link, usePage} from "@inertiajs/vue3";
+import {ArrowLeftOnRectangleIcon} from "@heroicons/vue/24/outline/index.js";
+import ThemeSwitcher from "../../ThemeSwitcher.vue";
+
+const page = usePage();
+</script>
+
+
 <template>
     <header
         class="sticky top-0 inset-x-0 flex flex-wrap sm:justify-start sm:flex-nowrap z-[48] w-full bg-white border-b text-sm py-2.5 sm:py-4 lg:pl-64 dark:bg-gray-800 dark:border-gray-700">
@@ -10,7 +19,9 @@
             </div>
 
             <div class="w-full flex items-center justify-end ml-auto sm:justify-between sm:gap-x-3 sm:order-3">
-                <div class="flex flex-row w-full items-center justify-end gap-2">
+                <div class="flex flex-row w-full items-center justify-end space-x-5">
+                    <ThemeSwitcher/>
+
                     <div class="hs-dropdown relative inline-flex [--placement:bottom-right]">
                         <button id="hs-dropdown-with-header" type="button"
                                 class="hs-dropdown-toggle inline-flex flex-shrink-0 justify-center items-center gap-2 h-[2.375rem] w-[2.375rem] rounded-full font-medium bg-white text-gray-700 align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:ring-offset-white transition-all text-xs dark:bg-gray-800 dark:hover:bg-slate-800 dark:text-gray-400 dark:hover:text-white dark:focus:ring-gray-700 dark:focus:ring-offset-gray-800">
@@ -43,10 +54,3 @@
         </nav>
     </header>
 </template>
-
-<script setup>
-import {Link, usePage} from "@inertiajs/vue3";
-import {ArrowLeftOnRectangleIcon} from "@heroicons/vue/24/outline/index.js";
-
-const page = usePage();
-</script>

--- a/resources/js/Components/ThemeSwitcher.vue
+++ b/resources/js/Components/ThemeSwitcher.vue
@@ -1,0 +1,30 @@
+<script setup>
+import {useColorMode} from "@vueuse/core";
+
+const mode = useColorMode();
+</script>
+
+<template>
+    <button @click="mode = 'dark'" :class="{
+        'hs-dark-mode-active:hidden hs-dark-mode group items-center text-gray-600 hover:text-blue-600 font-medium dark:text-gray-400 dark:hover:text-gray-500': true,
+        'hidden': mode === 'dark',
+        'flex': mode !== 'dark',
+    }" data-hs-theme-click-value="dark">
+        <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+             viewBox="0 0 16 16">
+            <path
+                d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278zM4.858 1.311A7.269 7.269 0 0 0 1.025 7.71c0 4.02 3.279 7.276 7.319 7.276a7.316 7.316 0 0 0 5.205-2.162c-.337.042-.68.063-1.029.063-4.61 0-8.343-3.714-8.343-8.29 0-1.167.242-2.278.681-3.286z"/>
+        </svg>
+    </button>
+    <button @click="mode = 'light'" :class="{
+        'hs-dark-mode-active:block hs-dark-mode group items-center text-gray-600 hover:text-blue-600 font-medium dark:text-gray-400 dark:hover:text-gray-500': true,
+        'hidden': mode === 'light',
+        'flex': mode !== 'light',
+    }" data-hs-theme-click-value="light">
+        <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+             viewBox="0 0 16 16">
+            <path
+                d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"/>
+        </svg>
+    </button>
+</template>

--- a/resources/js/Pages/Accreditations/Create.vue
+++ b/resources/js/Pages/Accreditations/Create.vue
@@ -2,11 +2,11 @@
     <AppLayout title="Catat Akreditasi">
         <div class="max-w-5xl w-full">
             <!-- Card -->
-            <div class="bg-white rounded-xl shadow p-4 sm:p-7 dark:bg-slate-900">
+            <div class="bg-white rounded-xl border border-gray-200 p-4 sm:p-7 dark:bg-gray-800 dark:border-gray-700">
                 <form @submit.prevent="submit">
                     <!-- Section -->
                     <div
-                        class="grid grid-cols-12 gap-4 py-8 first:pt-0 last:pb-0 border-t first:border-transparent border-gray-200 dark:border-gray-700">
+                        class="grid grid-cols-12 gap-4 py-8 first:pt-0 last:pb-0 first:border-transparent border-gray-200 dark:border-gray-700">
                         <div class="col-span-12">
                             <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200">
                                 Informasi Dasar
@@ -41,13 +41,14 @@
                             <select id="unit_id"
                                     v-model="form.unit_id"
                                     :disabled="units.length === 0"
-                                    class="py-3 px-4 block w-full rounded-md text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400">
+                                    class="py-3 border-gray-200  px-4 block w-full rounded-md text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400">
                                 <option selected></option>
                                 <option v-for="unit in units" :key="unit.id" :value="unit.id">
                                     {{ unit.name }} - {{ unit.unitable.degree }}
                                 </option>
                             </select>
-                            <p class="text-sm text-gray-500 mt-2" v-if="units.length === 0">Seluruh unit telah memiliki akreditasi.</p>
+                            <p class="text-sm text-gray-500 mt-2" v-if="units.length === 0">Seluruh unit telah memiliki
+                                akreditasi.</p>
                             <InputError id="unit_id" v-if="form.errors.unit_id">
                                 {{ form.errors.unit_id }}
                             </InputError>
@@ -64,7 +65,7 @@
                         <div class="col-span-9">
                             <select id="grade"
                                     v-model="form.grade"
-                                    class="py-3 px-4 block w-full rounded-md text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400">
+                                    class="py-3 px-4 block border-gray-200  w-full rounded-md text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400">
                                 <option selected></option>
                                 <option value="A">A</option>
                                 <option value="B">B</option>

--- a/resources/js/Pages/Accreditations/Index.vue
+++ b/resources/js/Pages/Accreditations/Index.vue
@@ -42,7 +42,7 @@
                                                 leave-from-class="opacity-100"
                                                 leave-to-class="transform opacity-0"
                                     >
-                                        <button v-if="checkedData.length >= 1" as="button"
+                                        <button v-if="checkedData.length >= 1"
                                                 @click="deleteCheckedAccreditation"
                                                 class="py-2 px-3 inline-flex justify-center items-center gap-2 rounded-md border border-transparent font-semibold bg-red-500 text-white hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-all text-sm dark:focus:ring-offset-gray-800"
                                         >
@@ -138,7 +138,7 @@
                                             <div class="px-6 py-3">
                                                 <span
                                                     class="block text-sm font-semibold text-gray-800 dark:text-gray-300">
-                                                {{ accreditation.unit.name }} {{ accreditation.unit.unitable.degree}}
+                                                {{ accreditation.unit.name }} {{ accreditation.unit.unitable.degree }}
                                                 </span>
                                                 <span
                                                     v-if="accreditation.status === 'active'"
@@ -160,7 +160,9 @@
                                             <div class="px-6 py-3">
                                                 <span
                                                     class="block text-sm font-semibold text-gray-800 dark:text-gray-300">
-                                                    {{ new Date(accreditation.decree.validity_date).toLocaleDateString() }}
+                                                    {{
+                                                        new Date(accreditation.decree.validity_date).toLocaleDateString()
+                                                    }}
                                             </span>
                                                 <span class="block text-sm text-gray-500">
                                                     {{ dayjs(accreditation.decree.validity_date).fromNow() }}

--- a/resources/js/Pages/Accreditations/Index.vue
+++ b/resources/js/Pages/Accreditations/Index.vue
@@ -129,7 +129,7 @@
                                         </td>
                                         <td class="h-px w-px whitespace-nowrap">
                                             <div class="pl-6 lg:pl-3 xl:pl-3 pr-6 py-3">
-                                                <span class="block text-sm text-gray-500">
+                                                <span class="block text-sm text-gray-800 dark:text-gray-300">
                                                     {{ accreditation.code }}
                                                 </span>
                                             </div>
@@ -137,7 +137,7 @@
                                         <td class="h-px w-px whitespace-nowrap">
                                             <div class="px-6 py-3">
                                                 <span
-                                                    class="block text-sm font-semibold text-gray-800 dark:text-gray-200">
+                                                    class="block text-sm font-semibold text-gray-800 dark:text-gray-300">
                                                 {{ accreditation.unit.name }} {{ accreditation.unit.unitable.degree}}
                                                 </span>
                                                 <span
@@ -151,7 +151,7 @@
                                         </td>
                                         <td class="h-px w-px whitespace-nowrap">
                                             <div class="px-6 py-3">
-                                                <span class="block text-sm text-gray-500">
+                                                <span class="block text-sm text-gray-800 dark:text-gray-300">
                                                     {{ accreditation.grade }}
                                                 </span>
                                             </div>
@@ -159,7 +159,7 @@
                                         <td class="h-px w-px whitespace-nowrap">
                                             <div class="px-6 py-3">
                                                 <span
-                                                    class="block text-sm font-semibold text-gray-800 dark:text-gray-200">
+                                                    class="block text-sm font-semibold text-gray-800 dark:text-gray-300">
                                                     {{ new Date(accreditation.decree.validity_date).toLocaleDateString() }}
                                             </span>
                                                 <span class="block text-sm text-gray-500">
@@ -223,7 +223,7 @@ const props = defineProps({
         default: '',
     },
     unitNotAccreditedCount: {
-        type: String,
+        type: Number,
         required: true,
     }
 });

--- a/resources/js/Pages/Data/Decree/Index.vue
+++ b/resources/js/Pages/Data/Decree/Index.vue
@@ -117,7 +117,6 @@ import InputField from "../../../Components/InputField.vue";
 import MainTable from "../../../Components/MainTable.vue";
 import HeaderTable from "../../../Components/HeaderTable.vue";
 import FooterTable from "../../../Components/FooterTable.vue";
-import {Link} from "@inertiajs/vue3";
 
 const props = defineProps({
     decrees: {

--- a/resources/js/Pages/Data/Decree/Index.vue
+++ b/resources/js/Pages/Data/Decree/Index.vue
@@ -79,7 +79,7 @@
                                         </td>
                                         <td class="h-px whitespace-nowrap">
                                             <div class="px-6 py-3">
-                                                <span class="block text-sm text-gray-500">
+                                                <span class="block text-sm text-gray-800 dark:text-gray-200">
                                                     {{ new Date(decree.release_date).toLocaleDateString() }}
                                                 </span>
                                             </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: 'class',
     content: [
         "./resources/**/*.blade.php",
         "./resources/**/*.js",


### PR DESCRIPTION
### ✨ Description 

added some features about dark mode

- create a new component `ThemeSwitcher` to toggle on dark or light mode
- fixed some pages not adapting to dark mode (dark classes)

This dark mode feature uses the `useColorMode` composable from the `@vueuse/core` package.

composable `useColorMode` stores the data of a theme client in a localstorage with a key `vueuse-color-scheme`.

Fixes # (issue)

### 🛠 Type of change 

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### ✅ Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
